### PR TITLE
Fix disk attachment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # A conventience dev/test Dockerfile.
-FROM registry.svc.ci.openshift.org/origin/4.1:base
-
+FROM fedora:30
+RUN dnf install -y e2fsprogs
 COPY bin/ovirt-csi-driver .
 
 ENTRYPOINT ["./ovirt-csi-driver"]

--- a/deploy/csi-driver/030-node.yaml
+++ b/deploy/csi-driver/030-node.yaml
@@ -75,7 +75,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
-            - name: plugin-dir
+            - name: socket-dir
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
@@ -100,10 +100,18 @@ spec:
 #            - name: kubelet-dir
 #              mountPath: /var/lib/kubelet
 #              mountPropagation: "Bidirectional"
-            - name: plugin-dir
+            - name: socket-dir
               mountPath: /csi
             - name: config
               mountPath: /tmp/config/
+            - name: plugin-dir
+              mountPath: /var/lib/kubelet/plugins
+              mountPropagation: Bidirectional
+            - name: host-dev
+              mountPath: /dev
+            - name: mountpoint-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
       volumes:
         - name: registration-dir
           hostPath:
@@ -115,7 +123,18 @@ spec:
             type: Directory
         - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/ovirt.org
+            path: /var/lib/kubelet/plugins
+            type: Directory
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/ovirt.org/
             type: DirectoryOrCreate
+        - name: host-dev
+          hostPath:
+            path: /dev
         - name: config
           emptyDir: {}
+        - name: mountpoint-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate


### PR DESCRIPTION
- Extract the disk ID from the volume ID (which is actually the disk attachment ID), and use only the first 20 characters since /dev/disk/by-id is truncated
- Use fedora 30 for now because we need to install e2fsprogs
- Fix the node.yaml and publishing/staging